### PR TITLE
feat: add ollama parse fallback

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -13,7 +13,7 @@ Backend feature foundation is in place, and the frontend now has a mobile-first 
 - PostgreSQL-backed tests and CI pipeline.
 - Authentication foundation: `User`, `ApiToken`, `RefreshSession`, auth service, auth routes, and tests.
 - Core finance domain: accounts, categories, transactions, repositories, schemas, and migrations.
-- Transaction ingestion from free-form text with authenticated parse-and-create flow, stronger parser heuristics for multiple numbers/type inference, API persistence coverage, and `.xlsx` bulk import into actual transactions for a chosen account.
+- Transaction ingestion from free-form text with authenticated parse-and-create flow, stronger parser heuristics for multiple numbers/type inference, feature-flagged Ollama LLM fallback for ambiguous text, API persistence coverage, and `.xlsx` bulk import into actual transactions for a chosen account.
 - Planned payments Stage 3: template-first model/CRUD semantics, projection-based lifecycle cleanup, and audit-only linkage from actual transactions.
 - Projected transactions Stage 1: model with status lifecycle, forecast layer between planned payments and transactions, and API endpoints for projection management.
 - Projection scheduler Stage 1: scheduled generation of pending projected transactions from planned-payment templates and scheduler health endpoint.
@@ -37,4 +37,5 @@ Backend feature foundation is in place, and the frontend now has a mobile-first 
 - Transaction editing refinement only if product later needs broader mutable fields such as `type`.
 - Additional API and integration coverage only where the roadmap explicitly calls for it.
 - Product refinement based on future feedback, especially around optional default-account selection.
+- LLM expansion candidates after parse fallback: Telegram assistant wiring, category suggestion, and report explanations.
 - Keep process guidance compact and prefer scripts plus docs over long ritual prompts.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ FinFlow currently supports:
 - accounts, categories, and actual transaction CRUD
 - transaction patch editing
 - parse-and-create ingestion from free-form text
+- optional Ollama-backed LLM fallback for ambiguous text parsing
 - bulk import of actual transactions from `.xlsx`
 - planned payment templates
 - projected transactions with edit, confirm, and skip flows
@@ -123,6 +124,7 @@ ruff format .
 - Backend and frontend are intended to run on the same origin in production-style setups.
 - Offline behavior is read-only by design for now; mutations are intentionally blocked without a connection.
 - `.xlsx` import currently expects the first sheet in `date / description / amount` order.
+- LLM parsing is feature-flagged and currently augments `parse-and-create` only when heuristics cannot confidently extract an amount.
 - Error responses use a normalized envelope so the frontend can localize and map them consistently.
 
 ## Status

--- a/backend/README.md
+++ b/backend/README.md
@@ -52,6 +52,12 @@ The backend service:
 - runs `uv sync --extra dev` inside the container into an isolated named virtualenv volume
 - applies `alembic upgrade head` before starting Uvicorn
 
+Optional LLM parsing fallback can be enabled with:
+- `OLLAMA_PARSE_ENABLED=true`
+- `OLLAMA_API_KEY=...`
+- `OLLAMA_API_BASE_URL=https://ollama.com/api`
+- `OLLAMA_MODEL=gpt-oss:120b`
+
 When dependencies change, restart the service or rerun `docker compose up --build`. When only Python source changes, `--reload` picks them up automatically.
 
 ## Practical lessons

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -34,6 +34,14 @@ class Settings(BaseSettings):
     api_token_length: int = 32
     api_token_expire_days: int = 365
 
+    # Ollama LLM fallback parsing
+    ollama_parse_enabled: bool = False
+    ollama_api_base_url: str = "https://ollama.com/api"
+    ollama_api_key: str | None = None
+    ollama_model: str = "gpt-oss:120b"
+    ollama_timeout_seconds: float = 20.0
+    ollama_parse_min_confidence: float = 0.75
+
     @property
     def is_production(self) -> bool:
         """Check if running in production mode."""

--- a/backend/app/integrations/__init__.py
+++ b/backend/app/integrations/__init__.py
@@ -1,0 +1,5 @@
+"""External integration clients."""
+
+from app.integrations.ollama_client import OllamaClient
+
+__all__ = ["OllamaClient"]

--- a/backend/app/integrations/ollama_client.py
+++ b/backend/app/integrations/ollama_client.py
@@ -1,0 +1,56 @@
+"""Minimal Ollama API client for structured chat completions."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from app.core.config import settings
+
+
+class OllamaClient:
+    """HTTP client for Ollama chat completions."""
+
+    def __init__(self) -> None:
+        self.base_url = settings.ollama_api_base_url.rstrip("/")
+        self.model = settings.ollama_model
+        self.timeout = settings.ollama_timeout_seconds
+        self.api_key = settings.ollama_api_key
+
+    async def chat(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+    ) -> str:
+        """Call the Ollama chat API and return assistant text content."""
+        headers: dict[str, str] = {
+            "Content-Type": "application/json",
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            "stream": False,
+        }
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(
+                f"{self.base_url}/chat",
+                headers=headers,
+                content=json.dumps(payload),
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        message = data.get("message", {})
+        content = message.get("content")
+        if not isinstance(content, str):
+            raise ValueError("Ollama response did not contain text content")
+        return content

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -40,6 +40,7 @@ from app.schemas.finance import (
     TransactionPatch,
     TransactionOut,
 )
+from app.schemas.llm import LLMTransactionParse
 from app.schemas.parse_create import (
     ParseAndCreateResponse,
     ParsedResult,
@@ -88,6 +89,8 @@ __all__ = [
     "CashflowReportResponse",
     "ReportCategoryTotal",
     "ReportTypeTotal",
+    # LLM
+    "LLMTransactionParse",
     # Parse-and-create
     "ParseRequest",
     "ParsedResult",

--- a/backend/app/schemas/llm.py
+++ b/backend/app/schemas/llm.py
@@ -1,0 +1,27 @@
+"""Schemas for LLM-assisted transaction parsing."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+from app.models.types import TransactionType
+
+
+class LLMTransactionParse(BaseModel):
+    """Structured parse payload expected back from the LLM."""
+
+    amount: Decimal | None = None
+    currency_code: str | None = None
+    transaction_type: TransactionType = TransactionType.EXPENSE
+    description: str | None = None
+    merchant: str | None = None
+    transaction_date: date | None = Field(default=None, alias="date")
+    category_hint: str | None = None
+    confidence: float = Field(ge=0.0, le=1.0)
+    needs_confirmation: bool = False
+    reason: str | None = None
+
+    model_config = {"populate_by_name": True}

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -2,6 +2,7 @@
 
 from app.services.auth_service import AuthService
 from app.services.cashflow_service import CashflowService
+from app.services.llm_parse_service import LLMParseService
 from app.services.parse_create_service import TransactionParseCreateService
 from app.services.projected_transaction_service import ProjectedTransactionService
 from app.services.projection_scheduler_service import ProjectionSchedulerService
@@ -11,6 +12,7 @@ from app.services.transaction_service import TransactionService
 __all__ = [
     "AuthService",
     "CashflowService",
+    "LLMParseService",
     "TransactionParseCreateService",
     "ProjectionSchedulerService",
     "ProjectedTransactionService",

--- a/backend/app/services/llm_parse_service.py
+++ b/backend/app/services/llm_parse_service.py
@@ -1,0 +1,96 @@
+"""LLM-backed fallback parser for ambiguous finance text."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import httpx
+from pydantic import ValidationError
+
+from app.core.config import settings
+from app.integrations.ollama_client import OllamaClient
+from app.schemas.llm import LLMTransactionParse
+from app.schemas.parse_create import ParsedResult
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_PROMPT = """
+You are a financial text extraction engine.
+Return only valid JSON.
+Do not include markdown, comments, or explanations.
+If the amount is unclear, set amount to null and needs_confirmation to true.
+If confidence is low, set needs_confirmation to true.
+Use transaction_type only from: income, expense, refund.
+Use category_hint only when you have a reasonable guess.
+""".strip()
+
+
+class LLMParseService:
+    """Converts free-form finance text into structured transaction data."""
+
+    def __init__(self, client: OllamaClient | None = None) -> None:
+        self.client = client or OllamaClient()
+
+    async def parse_text(self, text: str) -> ParsedResult | None:
+        """Return a structured fallback parse or None when not reliable."""
+        if not settings.ollama_parse_enabled:
+            return None
+
+        if not settings.ollama_api_key:
+            logger.debug("Skipping Ollama parse because OLLAMA_API_KEY is not configured")
+            return None
+
+        try:
+            content = await self.client.chat(
+                system_prompt=SYSTEM_PROMPT,
+                user_prompt=self._build_user_prompt(text),
+            )
+            payload = self._extract_json_payload(content)
+            parsed = LLMTransactionParse.model_validate(payload)
+        except (httpx.HTTPError, ValueError, ValidationError, json.JSONDecodeError) as exc:
+            logger.warning("LLM parse fallback failed: %s", exc)
+            return None
+
+        if parsed.amount is None:
+            return None
+        if parsed.needs_confirmation:
+            return None
+        if parsed.confidence < settings.ollama_parse_min_confidence:
+            return None
+
+        return ParsedResult(
+            amount=parsed.amount,
+            description=parsed.description or parsed.merchant or text,
+            category_name=parsed.category_hint,
+            transaction_type=parsed.transaction_type,
+            original_text=text,
+        )
+
+    def _build_user_prompt(self, text: str) -> str:
+        return (
+            "Extract a finance transaction from the text below.\n"
+            "Return JSON with keys: "
+            "amount, currency_code, transaction_type, description, merchant, "
+            "date, category_hint, confidence, needs_confirmation, reason.\n"
+            f"Text: {text}"
+        )
+
+    def _extract_json_payload(self, content: str) -> dict[str, object]:
+        cleaned = content.strip()
+        if cleaned.startswith("```"):
+            cleaned = cleaned.strip("`")
+            if cleaned.startswith("json"):
+                cleaned = cleaned[4:].strip()
+
+        start = cleaned.find("{")
+        end = cleaned.rfind("}")
+        if start == -1 or end == -1 or end < start:
+            raise ValueError("LLM response did not contain JSON")
+
+        parsed = json.loads(cleaned[start : end + 1])
+        if not isinstance(parsed, dict):
+            raise ValueError("LLM response JSON was not an object")
+        return parsed
+
+__all__ = ["LLMParseService"]

--- a/backend/app/services/parse_create_service.py
+++ b/backend/app/services/parse_create_service.py
@@ -10,13 +10,18 @@ from app.repositories.account_repository import AccountRepository
 from app.repositories.category_repository import CategoryRepository
 from app.repositories.transaction_repository import TransactionRepository
 from app.schemas.parse_create import ParseAndCreateResponse, ParsedResult
+from app.services.llm_parse_service import LLMParseService
 from app.services.parse_service import parse_text
 
 
 class TransactionParseCreateService:
     """Service for creating transactions from parsed free-form text."""
 
-    def __init__(self, session: AsyncSession):
+    def __init__(
+        self,
+        session: AsyncSession,
+        llm_parse_service: LLMParseService | None = None,
+    ):
         """Initialize the service with a database session.
 
         Args:
@@ -26,6 +31,7 @@ class TransactionParseCreateService:
         self.account_repo = AccountRepository(session)
         self.category_repo = CategoryRepository(session)
         self.transaction_repo = TransactionRepository(session)
+        self.llm_parse_service = llm_parse_service or LLMParseService()
 
     async def parse_and_create(
         self,
@@ -48,7 +54,7 @@ class TransactionParseCreateService:
         Raises:
             ValueError: If amount cannot be extracted from text.
         """
-        parsed = parse_text(text)
+        parsed = await self._parse_with_fallback(text)
 
         if parsed.amount is None:
             raise ValueError("Could not extract amount from text")
@@ -118,7 +124,18 @@ class TransactionParseCreateService:
         Returns:
             ParsedResult with extracted fields.
         """
-        return parse_text(text)
+        return await self._parse_with_fallback(text)
+
+    async def _parse_with_fallback(self, text: str) -> ParsedResult:
+        parsed = parse_text(text)
+        if parsed.amount is not None:
+            return parsed
+
+        llm_parsed = await self.llm_parse_service.parse_text(text)
+        if llm_parsed is not None:
+            return llm_parsed
+
+        return parsed
 
 
 __all__ = ["TransactionParseCreateService"]

--- a/backend/tests/api/test_parse_create_api.py
+++ b/backend/tests/api/test_parse_create_api.py
@@ -10,6 +10,8 @@ from app.models.types import AccountType, CategoryType
 from app.repositories.account_repository import AccountRepository
 from app.repositories.category_repository import CategoryRepository
 from app.repositories.transaction_repository import TransactionRepository
+from app.schemas.parse_create import ParsedResult
+from app.services.llm_parse_service import LLMParseService
 
 pytestmark = pytest.mark.api
 
@@ -175,3 +177,64 @@ class TestParseCreateAPI:
 
         assert response.status_code == 400
         assert _error_message(response) == "Account not found"
+
+    async def test_parse_and_create_uses_llm_fallback_when_enabled(
+        self,
+        async_client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """LLM fallback should create a transaction when heuristics miss the amount."""
+        user_id, access_token = await _register_and_login(
+            async_client, "parse-llm@example.com"
+        )
+
+        async with async_session_factory() as session:
+            account_repo = AccountRepository(session)
+            account = await account_repo.create(
+                user_id=user_id,
+                name="Main account",
+                type_=AccountType.CHECKING,
+            )
+            category_repo = CategoryRepository(session)
+            coffee_category = await category_repo.create(
+                user_id=user_id,
+                name="Кофе",
+                type_=CategoryType.EXPENSE,
+            )
+            await session.commit()
+
+        async def fake_parse_text(self: LLMParseService, text: str) -> ParsedResult | None:
+            del self
+            assert text == "кофе за триста пятьдесят"
+            return ParsedResult(
+                amount="350.00",
+                description="кофе",
+                category_name="Кофе",
+                transaction_type="expense",
+                original_text=text,
+            )
+
+        monkeypatch.setattr(
+            "app.services.llm_parse_service.settings.ollama_parse_enabled",
+            True,
+        )
+        monkeypatch.setattr(
+            LLMParseService,
+            "parse_text",
+            fake_parse_text,
+        )
+
+        response = await async_client.post(
+            "/api/v1/transactions/parse-and-create",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={
+                "text": "кофе за триста пятьдесят",
+                "account_id": str(account.id),
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["amount"] == "350.00"
+        assert data["category_id"] == str(coffee_category.id)
+        assert data["description"] == "кофе"

--- a/backend/tests/unit/test_llm_parse_service.py
+++ b/backend/tests/unit/test_llm_parse_service.py
@@ -1,0 +1,102 @@
+"""Unit tests for Ollama-backed parse fallback."""
+
+from decimal import Decimal
+
+from app.core.config import settings
+from app.schemas.parse_create import ParsedResult
+from app.services.llm_parse_service import LLMParseService
+
+
+class _FakeClient:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+    async def chat(self, *, system_prompt: str, user_prompt: str) -> str:
+        assert system_prompt
+        assert user_prompt
+        return self.content
+
+
+class TestLLMParseService:
+    async def test_parse_text_returns_structured_result_when_confident(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "ollama_parse_enabled", True)
+        monkeypatch.setattr(settings, "ollama_api_key", "test-key")
+        monkeypatch.setattr(settings, "ollama_parse_min_confidence", 0.75)
+
+        service = LLMParseService(
+            client=_FakeClient(
+                """
+                {
+                  "amount": "430.00",
+                  "currency_code": "RUB",
+                  "transaction_type": "expense",
+                  "description": "кофе и круассан",
+                  "merchant": "Surf Coffee",
+                  "date": null,
+                  "category_hint": "Кофе",
+                  "confidence": 0.91,
+                  "needs_confirmation": false,
+                  "reason": "Detected a purchase and ruble amount"
+                }
+                """
+            )
+        )
+
+        result = await service.parse_text("кофе и круассан за четыреста тридцать рублей")
+
+        assert isinstance(result, ParsedResult)
+        assert result is not None
+        assert result.amount == Decimal("430.00")
+        assert result.category_name == "Кофе"
+        assert result.transaction_type == "expense"
+
+    async def test_parse_text_returns_none_when_confidence_is_too_low(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "ollama_parse_enabled", True)
+        monkeypatch.setattr(settings, "ollama_api_key", "test-key")
+        monkeypatch.setattr(settings, "ollama_parse_min_confidence", 0.75)
+
+        service = LLMParseService(
+            client=_FakeClient(
+                """
+                {
+                  "amount": "430.00",
+                  "currency_code": "RUB",
+                  "transaction_type": "expense",
+                  "description": "что-то по еде",
+                  "merchant": null,
+                  "date": null,
+                  "category_hint": null,
+                  "confidence": 0.49,
+                  "needs_confirmation": false,
+                  "reason": "Low certainty"
+                }
+                """
+            )
+        )
+
+        result = await service.parse_text("что-то вкусное рублей на четыреста+")
+
+        assert result is None
+
+    async def test_parse_text_returns_none_when_ollama_disabled(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "ollama_parse_enabled", False)
+        monkeypatch.setattr(settings, "ollama_api_key", "test-key")
+
+        service = LLMParseService(
+            client=_FakeClient(
+                '{"amount":"100.00","transaction_type":"expense","confidence":0.99}'
+            )
+        )
+
+        result = await service.parse_text("обед без цифр")
+
+        assert result is None

--- a/compose.yml
+++ b/compose.yml
@@ -25,6 +25,10 @@ services:
     environment:
       DEBUG: "true"
       DATABASE_URL: postgresql+asyncpg://finflow:finflow@db:5432/finflow
+      OLLAMA_PARSE_ENABLED: ${OLLAMA_PARSE_ENABLED:-false}
+      OLLAMA_API_BASE_URL: ${OLLAMA_API_BASE_URL:-https://ollama.com/api}
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
+      OLLAMA_MODEL: ${OLLAMA_MODEL:-gpt-oss:120b}
       UV_LINK_MODE: copy
       UV_PROJECT_ENVIRONMENT: /opt/finflow-venv
     command: >

--- a/docs/agent/features/transaction-ingestion.md
+++ b/docs/agent/features/transaction-ingestion.md
@@ -10,6 +10,7 @@ stored transaction.
 - transaction creation service
 - workbook import service
 - heuristic parser fallback for free-form text
+- optional Ollama LLM fallback parser for ambiguous text
 - endpoint for iOS Shortcut ingestion
 - endpoint for `.xlsx` batch import into actual transactions
 - tests for happy path, invalid input, auth, and real persistence behavior
@@ -36,6 +37,7 @@ Bulk import contract:
 - Extract amount from text using regex/heuristics.
 - Prefer the amount explicitly marked as money when multiple numbers appear.
 - If no money marker is present, prefer the trailing amount over an earlier count.
+- If heuristics still cannot determine an amount, an optional LLM fallback may return structured JSON with confidence gating.
 - Preserve a cleaned human-readable description rather than storing raw text unchanged.
 - Infer category only when confidence is reasonable; otherwise allow uncategorized transaction.
 - Infer transaction type only for simple high-confidence cases such as income/refund keywords.
@@ -46,6 +48,7 @@ Bulk import contract:
 - Route remains thin.
 - Parsing logic lives in a service/helper module.
 - Keep parser implementation replaceable by future LLM-based parsing.
+- LLM integration must stay behind config flags and return strict JSON validated by Pydantic before any persistence.
 - Validate real account/category ownership before persisting.
 - Use authenticated DB lookups for account and optional category before creating the transaction.
 - For workbook import, validate the selected account once before row ingestion and report row-level parse issues without failing the whole file.

--- a/docs/spec/backend.md
+++ b/docs/spec/backend.md
@@ -7,6 +7,7 @@ FinFlow backend supports:
 - long-lived API tokens for iOS Shortcut
 - accounts, categories, transactions, planned-payment templates, and projected transactions
 - parse-and-create ingestion from free-form text
+- optional Ollama-backed fallback parsing for ambiguous free-form text
 - workbook import of actual transactions from `.xlsx`
 - BDR/accrual and BDDS/cashflow reports
 - unified cashflow ledger and forecast reads over actual plus projected data
@@ -20,6 +21,7 @@ The backend foundation is in place through:
 - scheduler-backed projection generation
 - reporting plus cashflow ledger/forecast
 - refined parse-and-create ingestion coverage
+- feature-flagged LLM fallback for parse-and-create
 - `.xlsx` transaction import into actual transactions
 - normalized API error envelopes with stable error codes and field maps
 
@@ -46,6 +48,7 @@ Main API groups under `/api/v1`:
 - Request body is `text`, required `account_id`, and optional `category_id`.
 - Separate bulk-import flow accepts multipart form-data with required `account_id` and `.xlsx` file.
 - Parser uses deterministic heuristics for amount, description, category hints, and simple income/refund inference.
+- If heuristics cannot confidently extract an amount, the backend may optionally call an Ollama-compatible chat model for a strict JSON fallback parse.
 - Ownership of account/category is validated against the authenticated user before persistence.
 - If `category_id` is omitted, the service may auto-match a user category by detected category name.
 - Workbook import reads the first sheet in `date / description / amount` order, infers income vs expense from the sign, and returns imported/skipped row summary.


### PR DESCRIPTION
## Summary
- add a feature-flagged Ollama client and LLM parse service for ambiguous transaction text
- wire the fallback into parse-and-create without changing the existing deterministic fast path
- document local config for Ollama-backed parsing in backend docs and compose

## What changed
- added OllamaClient for https://ollama.com/api/chat
- added LLMTransactionParse schema and strict JSON validation
- added LLMParseService with confidence gating and safe fallback behavior
- updated TransactionParseCreateService to call the LLM only when heuristics fail to extract an amount
- added unit coverage for LLM parse behavior and API coverage for end-to-end fallback persistence
- documented OLLAMA_PARSE_ENABLED, OLLAMA_API_KEY, OLLAMA_API_BASE_URL, and OLLAMA_MODEL

## Validation
- cd backend && uv run python -m mypy app --show-error-codes --pretty
- cd backend && uv run python -m pytest tests -q
- cd backend && uv run ruff check app/integrations/__init__.py app/integrations/ollama_client.py app/schemas/llm.py app/services/llm_parse_service.py app/services/parse_create_service.py tests/unit/test_llm_parse_service.py tests/api/test_parse_create_api.py

## Notes
- rollout is opt-in: OLLAMA_PARSE_ENABLED=false by default
- if Ollama is unavailable, low-confidence, or returns invalid JSON, the endpoint keeps existing behavior and does not silently create a transaction
- this PR intentionally limits LLM usage to parse-and-create; the same service can later be reused in Telegram when that integration lands on main